### PR TITLE
add instructions to install a systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,36 @@ can be run with `--configure` to pop-up its configuration window, that
 allows to tune its notification behaviour and to edit the configuration
 files for `smd-loop` and `smd-push/pull`.
 
+### systemd integration
+
+`smd-pull` and `smd-push` can be configured as user services that get
+automatically run under [`systemd`][]. The following units are provided:
+
+- [`smd-push.service`](misc/smd-push.service)
+- [`smd-push.timer`](misc/smd-push.timer)
+- [`smd-pull.service`](misc/smd-pull.service)
+- [`smd-pull.timer`](misc/smd-pull.timer)
+
+Those should be installed in `~/.config/systemd/user/` and enabled
+like this:
+
+    systemctl --user daemon-reload
+    systemctl enable smd-push.service smd-push.timer smd-pull.service smd-pull.timer
+
+Then you should see progress from those jobs in the journal:
+
+    journalctl --user -f
+
+You might need to enable [`journald`][] persistence by enabling the
+`Storage` paramter in [`journald.conf`][]. This is generally simply a
+matter of creating the storage directory, with:
+
+    sudo mkdir /var/log/journal
+
+[`systemd`]: https://freedesktop.org/wiki/Software/systemd/
+[`journald`]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
+[`journald.conf`]: https://www.freedesktop.org/software/systemd/man/journald.conf.html
+
 Notes on performances
 ---------------------
 

--- a/misc/smd-pull.service
+++ b/misc/smd-pull.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=pull emails with syncmaildir
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+# --show-tags gives email counts
+ExecStart=/usr/bin/smd-pull --show-tags
+
+[Install]
+WantedBy=multi-user.target

--- a/misc/smd-pull.timer
+++ b/misc/smd-pull.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=run smd-pull regularly
+
+[Timer]
+OnCalendar=*:0/2
+
+[Install]
+WantedBy=timers.target

--- a/misc/smd-push.service
+++ b/misc/smd-push.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=push emails with syncmaildir
+Wants=network-online.target
+After=smd-pull.service
+
+[Service]
+Type=oneshot
+# --show-tags gives email counts
+ExecStart=/usr/bin/smd-push --show-tags
+
+[Install]
+WantedBy=multi-user.target

--- a/misc/smd-push.timer
+++ b/misc/smd-push.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=run smd-push regularly
+
+[Timer]
+OnCalendar=*:0/2
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
I have removed the `--verbose` option which I tested here because it
doesn't do anything, see #11.

Otherwise this is pretty much what I'm using in production now.

Closes: #10