### PR TITLE
Implement xdelta3 and fix lua env replacement 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: main
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-16.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get install txt2man pkg-config libglib2.0-dev libgtk-3-dev libnotify-dev libgee-0.8-dev lua5.1 moreutils xdelta3
+    - name: build
+      run: make
+    - name: test
+      run: make test
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: test-logs
+        path: tests.d/run/*/*/log.*

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ H=@
 
 PREFIX=usr/local
 SED=sed
-XDELTA=xdelta
+XDELTA=xdelta3
 SSH=ssh
 LUAV=5.1
 LUA=lua$(LUAV)
@@ -150,7 +150,7 @@ define install-replacing
 		$(SED) 's?@XDELTA@?$(XDELTA)?' |\
 		$(SED) 's?@SSH@?$(SSH)?' |\
 		$(SED) 's?@SMDVERSION@?$(VERSION)?' |\
-		$(SED) 's?#! /usr/bin/env lua.*?#! /usr/bin/env $(LUA)?' |\
+		$(SED) 's?#!/usr/bin/env lua.*?#!/usr/bin/env $(LUA)?' |\
 		cat > $(DESTDIR)/$(PREFIX)/$(2)/$(1)
 	if [ $(2) = "bin" ]; then chmod a+rx $(DESTDIR)/$(PREFIX)/$(2)/$(1); fi
 endef

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ supported by templates defined at the end of `Makefile`, for example you may
 want to run `make osx/text/all && make osx/text/install` to properly build and
 install text mode only syncmaildir utilities on an MacOSX platform.
 
-Runtime dependencies are: `ssh`, `xdelta`, `lua5.1` and `bash`.
+Runtime dependencies are: `ssh`, `xdelta3`, `lua5.1` and `bash`.
 
 Design
 ======

--- a/smd-client
+++ b/smd-client
@@ -1,4 +1,4 @@
-#! /usr/bin/env lua5.1
+#!/usr/bin/env lua5.1
 -- 
 -- Released under the terms of GPLv3 or at your option any later version.
 -- No warranties.
@@ -762,7 +762,7 @@ function main()
 
 	local rc
 	if not dry_run() and apply_xdelta then
-		rc = os.execute(XDELTA..' patch '..xdelta..' '..dbfile..' '..newdb)
+		rc = os.execute(XDELTA..' -d -s '..dbfile..' '..xdelta..'  '..newdb)
 	else
 		rc = 0 -- the xdelta transmitted with --dry-run is dummy
 	end

--- a/smd-client
+++ b/smd-client
@@ -762,7 +762,7 @@ function main()
 
 	local rc
 	if not dry_run() and apply_xdelta then
-		rc = os.execute(XDELTA..' -d -s '..dbfile..' '..xdelta..'  '..newdb)
+		rc = os.execute(XDELTA..' -d -s '..dbfile..' '..xdelta..' '..newdb)
 	else
 		rc = 0 -- the xdelta transmitted with --dry-run is dummy
 	end

--- a/smd-server
+++ b/smd-server
@@ -1,4 +1,4 @@
-#! /usr/bin/env lua5.1
+#!/usr/bin/env lua5.1
 -- 
 -- Released under the terms of GPLv3 or at your option any later version.
 -- No warranties.
@@ -162,7 +162,7 @@ function main()
 			local rc
 			if not dry_run() then
 				rc = os.execute(
-					XDELTA..' delta '..dbfile..' '..newdb..' '..xdelta)
+					XDELTA..' -e -s '..dbfile..' '..newdb..' '..xdelta)
 			else
 				local f = io.open(xdelta,'w')
 				f:close()

--- a/syncmaildir.lua
+++ b/syncmaildir.lua
@@ -31,7 +31,7 @@ end
 -- set xdelta executable name
 XDELTA = '@XDELTA@'
 if string.sub(XDELTA,1,1) == '@' then
-		XDELTA = 'xdelta'
+		XDELTA = 'xdelta3'
 end
 
 -- set smd version 


### PR DESCRIPTION
This implements xdelta3 instead of xdelta. The two versions are
incompatible. While some Linux distributions, such as Debian,
provide xdelta and xdelta3 where both work according to their
version, other distributions, such as Fedora, only provide the
functionality of xdelta3 and symlink xdelta to xdelta3. This means
that syncmaildir can not run on those distributions. By switching
to xdelta3, most modern distributions should be supported.
The syntax on how to generate a delta file as well as how to apply
one is different in xdelta3 as well. This has been accounted for in
the change.

Replacing the lua env shebang in the Makefile was only working for
some of the lua files included in the project. This has been unified
to work for all lua files by altering the Makefile as well as the
two lua files smd-server and smd-client. The shebang now does not
contain a space after it (#!/usr/bin/env). That is arguably the
most common implementation, so the change accounts for that in the
Makefile too.